### PR TITLE
bugfix in setup.py

### DIFF
--- a/dwdweather.py
+++ b/dwdweather.py
@@ -8,7 +8,12 @@ import json
 import math
 import sqlite3
 import argparse
-import StringIO
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+    
 import traceback
 from ftplib import FTP
 from zipfile import ZipFile
@@ -878,7 +883,7 @@ def main():
 
     def get_station(args):
         dw = DwdWeather(cachepath=args.cachepath, verbosity=args.verbosity)
-        print json.dumps(dw.nearest_station(lon=args.lon, lat=args.lat), indent=4)
+        print(json.dumps(dw.nearest_station(lon=args.lon, lat=args.lat), indent=4))
 
     def get_stations(args):
         dw = DwdWeather(cachepath=args.cachepath, verbosity=args.verbosity)
@@ -890,7 +895,7 @@ def main():
         elif args.type == "plain":
             output = dw.stations_csv(delimiter="\t")
         if args.output_path is None:
-            print output
+            print(output)
         else:
             f = open(args.output_path, "wb")
             f.write(output)
@@ -899,7 +904,7 @@ def main():
     def get_weather(args):
         hour = datetime.strptime(str(args.hour), "%Y%m%d%H")
         dw = DwdWeather(cachepath=args.cachepath, verbosity=args.verbosity)
-        print json.dumps(dw.query(args.station_id, hour), indent=4, sort_keys=True)
+        print(json.dumps(dw.query(args.station_id, hour), indent=4, sort_keys=True))
 
     argparser = argparse.ArgumentParser(prog="dwdweather",
         description="Get weather information for Germany.")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (IOError, ImportError):
     description = ''
 
 setup(name='dwdweather',
-      version='0.7',
+      version='0.7.1',
       description='Inofficial DWD weather data client (Deutscher Wetterdienst)',
       long_description=description,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 try:
     import pypandoc
-    description = pypandoc.convert('README.md', 'rst')
+    description = pypandoc.convert('README.md', 'rst', format='md')
 except (IOError, ImportError):
     description = ''
 
@@ -12,6 +12,7 @@ setup(name='dwdweather',
       version='0.7',
       description='Inofficial DWD weather data client (Deutscher Wetterdienst)',
       long_description=description,
+      long_description_content_type='text/markdown',
       author='Marian Steinbach',
       author_email='marian@sendung.de',
       url='http://github.com/marians/dwd-weather',


### PR DESCRIPTION
Bugfix for proper installation...

Error before:

> pip install dwdweather
Collecting dwdweather
  Downloading https://files.pythonhosted.org/packages/ee/4f/4bd3ceff7b6158133d6e7cbfd68f27e4d72fd2f80c83d032944e16bbbb2f/dwdweather-0.7.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "...dwdweather\setup.py", line 7, in <module>
        description = pypandoc.convert('README.md', 'rst')
      File "...pypandoc\__init__.py", line 66, in convert
        raise RuntimeError("Format missing, but need one (identified source as text as no "
    RuntimeError: Format missing, but need one (identified source as text as no file with that name was found).

    ----------------------------------------